### PR TITLE
Check if coursetilestyle is set before checking the value

### DIFF
--- a/classes/output/core/course_renderer.php
+++ b/classes/output/core/course_renderer.php
@@ -47,7 +47,8 @@ global $PAGE;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-if ($PAGE->theme->settings->coursetilestyle < 10) {
+$themesettings = $PAGE->theme->settings;
+if (isset($themesettings->coursetilestyle) && $themesettings->coursetilestyle < 10) {
 
 class course_renderer extends \core_course_renderer  {
     protected $countcategories = 0;


### PR DESCRIPTION
Currently if the coursetilestyle setting hasn't been set yet the theme will throw an undefined property. This is particularly troublesome for unit tests as they will fail. Simple solution is to check if the property is set.